### PR TITLE
Allows to hide series with certain tags from the Series Management

### DIFF
--- a/.envexample
+++ b/.envexample
@@ -1,28 +1,28 @@
-
-1# Required
+# Required
 SONARR_URL=http://your-sonarr:8989
 SONARR_API_KEY=your_sonarr_api_key
 TMDB_API_KEY=your_tmdb_api_key
-      
+
 # Optional - Viewing-based rules
 TAUTULLI_URL=http://your-tautulli:8181
 TAUTULLI_API_KEY=your_tautulli_key
 # OR
 JELLYFIN_URL=http://your-jellyfin:8096
 JELLYFIN_API_KEY=your_jellyfin_key
-      
+
 # Optional - Request integration
 JELLYSEERR_URL=http://your-jellyseerr:5055
 JELLYSEERR_API_KEY=your_jellyseerr_key
-# OR  
+# OR
 OVERSEERR_URL=http://your-overseerr:5055
 OVERSEERR_API_KEY=your_overseerr_key
-      
+
 # Optional - Tag creation (defaults to false)
 EPISEERR_AUTO_CREATE_TAGS=false
-      
+
+# Optional - Hide series with these tags (IDs or names, comma-separated)
+# Examples: HIDE_TAGS=2, 7 or HIDE_TAGS=Watched, Hidden or mixed: HIDE_TAGS=2, Watched
+HIDE_TAGS=
 
 LOG_PATH=logs/app.log
 FLASK_DEBUG=false
-
-


### PR DESCRIPTION
I am using Sonarr to keep track of all series I have watched so far. For this I have created a `watched` filter in Sonarr:
<img width="796" height="152" alt="image" src="https://github.com/user-attachments/assets/c1ed3293-de97-4c8a-8ad2-12a8a69140ff" />

Every series, which has ended and I finished watching, I manually tag with `watched`. And in the series overview in Sonarr, I select to only see the unwatched series:
<img width="790" height="164" alt="image" src="https://github.com/user-attachments/assets/aaabc9be-034f-405a-84b9-91b2357d86b7" />

Overview for all series in Sonarr:
<img width="316" height="62" alt="image" src="https://github.com/user-attachments/assets/a494e365-3960-48e7-a60f-90853aa44930" />

Applying the `watched` filter:
<img width="304" height="68" alt="image" src="https://github.com/user-attachments/assets/015e567c-fc66-41f7-ae2a-6b1386744164" />

With that, I have a much better overview of my "todos" :)

Now Episeerr, by default, doesn't care about this, and is always showing all series from Sonarr, no matter what. But as long, as I have watched a series, I do not want to change anything in the rule assignment in Episeerr.

Hence I want to not see any series in Episeerr, which has certain tag(s).

The `.env[example]` file now contains a new optional key `HIDE_TAGS=`. This key can be given ID(s) or name(s) of the tag(s) of the series from Sonarr, which should not be showing up in the Series Management of Episeerr.
It is being error-proven, if this name or ID actually exist in Sonarr. If not, it is being ignored.