### PR TITLE
Add explicit contents:write permission to sync.yml

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   sync_with_upstream:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout target repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Part of the GitHub public-repo security baseline. Once this repo's default Actions workflow permissions are switched to read-only, the fork-sync job needs an explicit `contents: write` permission to push to `main`. Not auto-merged - please review and merge.