### PR TITLE
Fix sync: pin gh PR base to fork via GH_REPO

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Sync upstream via pull request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # In a fork checkout, gh defaults to the parent repo (Vansmak) as
+          # PR base; pin it to this repo.
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
gh in a fork checkout defaults the PR base to the parent repo (Vansmak/episeerr), where GITHUB_TOKEN has no permissions — `Resource not accessible by integration`. Pin `GH_REPO` to this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)